### PR TITLE
Fix atomic vectors, version/URL strings, and decimal to int conversion

### DIFF
--- a/R/BIOM-class.R
+++ b/R/BIOM-class.R
@@ -182,7 +182,7 @@ make_biom <- function(data, sample_metadata=NULL, observation_metadata=NULL, id=
   names(datalist) <- NULL
   # Define the list, instantiate as biom-format, and return
   # (Might eventually expose some of these list elements as function arguments)
-  format_url = "http://biom-format.org/documentation/format_versions/biom-1.0.html"
+  format_url = "http://biom-format.org"
   return(biom(list(id=id,
                    format = "Biological Observation Matrix 1.0.0-dev",
                    format_url = format_url,

--- a/R/BIOM-class.R
+++ b/R/BIOM-class.R
@@ -184,7 +184,7 @@ make_biom <- function(data, sample_metadata=NULL, observation_metadata=NULL, id=
   # (Might eventually expose some of these list elements as function arguments)
   format_url = "http://biom-format.org"
   return(biom(list(id=id,
-                   format = "Biological Observation Matrix 1.0.0-dev",
+                   format = "Biological Observation Matrix 1.0.0",
                    format_url = format_url,
                    type = "OTU table",
                    generated_by = sprintf("biomformat %s", packageVersion("biomformat")),

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -121,7 +121,7 @@ read_biom <- function(biom_file){
 #' y = read_biom(outfile)
 #' identical(x, y) 
 write_biom <- function(x, biom_file){
-	cat(toJSON(x, auto_unbox=TRUE), file=biom_file)
+	cat(toJSON(x, always_decimal=TRUE, auto_unbox=TRUE), file=biom_file)
 }
 ################################################################################
 #' Read in a biom-format vs 2 file, returning a \code{list}.

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -121,7 +121,7 @@ read_biom <- function(biom_file){
 #' y = read_biom(outfile)
 #' identical(x, y) 
 write_biom <- function(x, biom_file){
-	cat(toJSON(x), file=biom_file)
+	cat(toJSON(x, auto_unbox=TRUE), file=biom_file)
 }
 ################################################################################
 #' Read in a biom-format vs 2 file, returning a \code{list}.


### PR DESCRIPTION
See issue #1.

I've also edited the format and format_url entries to match the expected values in the validate_table script that is part of the official biom-format library (see commits for links).

The final change is ensuring that decimals remain decimals after converting to JSON.