### PR TITLE
Fix unidentical biom output by make_biom()

### DIFF
--- a/R/BIOM-class.R
+++ b/R/BIOM-class.R
@@ -165,15 +165,19 @@ setMethod("biom", c("list"), function(x){
 make_biom <- function(data, sample_metadata=NULL, observation_metadata=NULL, id=NULL, matrix_element_type="int"){
   # The observations / features / OTUs / rows "meta" data table
   if(!is.null(observation_metadata)){
+    observation_metadata = as.data.frame(observation_metadata)
+    colnames(observation_metadata) = NULL
     rows = mapply(list, SIMPLIFY=FALSE, id=as.list(rownames(data)),
-                  metadata=alply(as.matrix(observation_metadata), 1, .expand=FALSE, .dims=TRUE))
+                  metadata=alply(as.matrix(observation_metadata), 1, function(x) list(taxonomy = x),
+				 .expand=FALSE, .dims=TRUE))
   } else {
     rows = mapply(list, id=as.list(rownames(data)), metadata=NA, SIMPLIFY=FALSE)
   }
   # The samples / sites / columns "meta" data table
   if(!is.null(sample_metadata)){
     columns = mapply(list, SIMPLIFY=FALSE, id=as.list(colnames(data)),
-                     metadata=alply(as.matrix(sample_metadata), 1, .expand=FALSE, .dims=TRUE)) 
+                     metadata=alply(as.matrix(sample_metadata), 1, function(x) data.frame(t(x)),
+				    .expand=FALSE, .dims=TRUE)) 
   } else {
     columns = mapply(list, id=as.list(colnames(data)), metadata=NA, SIMPLIFY=FALSE)
   }

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -121,7 +121,7 @@ read_biom <- function(biom_file){
 #' y = read_biom(outfile)
 #' identical(x, y) 
 write_biom <- function(x, biom_file){
-	cat(toJSON(x, always_decimal=TRUE, auto_unbox=TRUE), file=biom_file)
+	cat(toJSON(x, always_decimal=TRUE, auto_unbox=TRUE, pretty=TRUE), file=biom_file)
 }
 ################################################################################
 #' Read in a biom-format vs 2 file, returning a \code{list}.


### PR DESCRIPTION
PR to fix unidentical BIOM output produced by the `make_biom` function. Without the fix, 
- `observation_metadata`: `metadata` stores taxonomy information in the wrong JSON structure.
- `sample_metadata`: `metadata` is unable to store the associated column names in the output.

Additionally, the `pretty=TRUE` flag is added to the `toJSON` function used in the `write_biom` function to improve readability, useful for debugging or for anyone wish to read the `biom` file.

```R
     # import with default parameters, specify a file
     biomfile = system.file("extdata", "rich_dense_otu_table.biom", package = "biomformat")
     x = read_biom(biomfile)
     data = biom_data(x)
     data
     smd = sample_metadata(x)
     omd = observation_metadata(x)
     # Make a new biom object from component data
     y = make_biom(data, smd, omd)
     # Won't be identical to x because of header info.
     identical(x, y)

     # The data components should be, though.
     identical(observation_metadata(x), observation_metadata(y))
     identical(sample_metadata(x), sample_metadata(y))
     identical(biom_data(x), biom_data(y))
```

```
[1] FALSE
[1] TRUE
[1] TRUE
[1] TRUE
```

```R
     ## Quickly show that writing and reading still identical.
     # Define a temporary directory to write .biom files
     tempdir = tempdir()
     write_biom(x, biom_file=file.path(tempdir, "x.biom"))
     write_biom(y, biom_file=file.path(tempdir, "y.biom"))
     x1 = read_biom(file.path(tempdir, "x.biom"))
     y1 = read_biom(file.path(tempdir, "y.biom"))
     identical(observation_metadata(x1), observation_metadata(y1))
     identical(sample_metadata(x1), sample_metadata(y1))
     identical(biom_data(x1), biom_data(y1))
```

```
[1] TRUE
[1] TRUE
[1] TRUE
```

Also tested using the `import_biom` function from `phyloseq` to import BIOM file to a `phyloseq` object

```R
library(phyloseq)
library(biomformat)
data(GlobalPatterns)

gp <- prune_taxa(c("549322","522457"), GlobalPatterns)
gp <- prune_samples(c("CL3","AQC1cm"), gp)

biomfile = make_biom(data = as.matrix(otu_table(gp)),
                     sample_metadata = sample_data(gp),
                     observation_metadata = tax_table(gp),
                     id = "None")

write_biom(biomfile, "test.biom")
test = import_biom("test.biom")
colnames(tax_table(test)) = c("Kingdom","Phylum","Class","Order","Family","Genus","Species")
```

```
> gp
phyloseq-class experiment-level object
otu_table()   OTU Table:         [ 2 taxa and 2 samples ]
sample_data() Sample Data:       [ 2 samples by 7 sample variables ]
tax_table()   Taxonomy Table:    [ 2 taxa by 7 taxonomic ranks ]
phy_tree()    Phylogenetic Tree: [ 2 tips and 1 internal nodes ]
> test
phyloseq-class experiment-level object
otu_table()   OTU Table:         [ 2 taxa and 2 samples ]
sample_data() Sample Data:       [ 2 samples by 7 sample variables ]
tax_table()   Taxonomy Table:    [ 2 taxa by 7 taxonomic ranks ]
```

```
> otu_table(gp)
OTU Table:          [2 taxa and 2 samples]
                     taxa are rows
       CL3 AQC1cm
549322   0     27
522457   0      0
> otu_table(test)
OTU Table:          [2 taxa and 2 samples]
                     taxa are rows
       CL3 AQC1cm
549322   0     27
522457   0      0
```

```
> sample_data(gp)
Sample Data:        [2 samples by 7 sample variables]:
       X.SampleID  Primer Final_Barcode Barcode_truncated_plus_T Barcode_full_length         SampleType                              Description
CL3           CL3 ILBC_01        AACGCA                   TGCGTT         CTAGCGTGCGT               Soil Calhoun South Carolina Pine soil, pH 4.9
AQC1cm     AQC1cm ILBC_16        ACAGCA                   TGCTGT         GACCACTGCTG Freshwater (creek)             Allequash Creek, 0-1cm depth
> sample_data(test)
Sample Data:        [2 samples by 7 sample variables]:
       X.SampleID  Primer Final_Barcode Barcode_truncated_plus_T Barcode_full_length         SampleType                              Description
CL3           CL3 ILBC_01        AACGCA                   TGCGTT         CTAGCGTGCGT               Soil Calhoun South Carolina Pine soil, pH 4.9
AQC1cm     AQC1cm ILBC_16        ACAGCA                   TGCTGT         GACCACTGCTG Freshwater (creek)             Allequash Creek, 0-1cm depth
```

```
> tax_table(gp)
Taxonomy Table:     [2 taxa by 7 taxonomic ranks]:
       Kingdom   Phylum          Class          Order Family Genus Species
549322 "Archaea" "Crenarchaeota" "Thermoprotei" NA    NA     NA    NA     
522457 "Archaea" "Crenarchaeota" "Thermoprotei" NA    NA     NA    NA     
> tax_table(test)
Taxonomy Table:     [2 taxa by 7 taxonomic ranks]:
       Kingdom   Phylum          Class          Order Family Genus Species
549322 "Archaea" "Crenarchaeota" "Thermoprotei" NA    NA     NA    NA     
522457 "Archaea" "Crenarchaeota" "Thermoprotei" NA    NA     NA    NA     
```