### PR TITLE
Fix biom_data() when dealing with 1-taxon and 1-sample BIOM data

### DIFF
--- a/R/BIOM-class.R
+++ b/R/BIOM-class.R
@@ -572,21 +572,19 @@ setMethod("biom_data", c("biom", "numeric", "numeric"), function(x, rows, column
     m = m[rows, columns]
   # End sparse section
   }   
-  # Add row and column names
+  # If either dimension is length-one
   if( identical(length(rows), 1L) | identical(length(columns), 1L) ){
-    # If either dimension is length-one
-    # Try naming by colnames first, then rownames
     if( identical(length(rows), 1L) ){
-      names(m) <- sapply(x$columns[columns], function(i) i$id )
+      # If row is length-one (1 taxon)
+      m = t(as.matrix(m))
     } else {
-      names(m) <- sapply(x$rows[rows], function(i) i$id )
+      # If column is length-one (1 sample)
+      m = as.matrix(m)
     }
-  } else {
-    # Else, both dimensions are longer than 1,
-    # can assume is a matrix and assign names to both dimensions
-    rownames(m) <- sapply(x$rows[rows], function(i) i$id )
-    colnames(m) <- sapply(x$columns[columns], function(i) i$id )
   }
+  # Add row and column names
+  rownames(m) <- sapply(x$rows[rows], function(i) i$id )
+  colnames(m) <- sapply(x$columns[columns], function(i) i$id )
   return(m)
 })
 ################################################################################


### PR DESCRIPTION
PR fix the matrix `m` returned by the `biom_data` function when either dimension of BIOM is length-one.

https://github.com/joey711/biomformat/blob/4e13f6fb3611b715b1c5b87d62c851f65d1453b6/R/BIOM-class.R#L575-L584

Without the fix, the structure of the returned object `m` is wrong and is missing either the taxon ID (`test1.biom`) or sample ID (`test2.biom`).

```
> biom_data(read_biom("test1.biom"))
   CL3 AQC1cm 
     0     27 

> biom_data(read_biom("test2.biom"))
549322 522457 
    27      0 
```
With the fix, the returned object has correct structure (i.e. rows are taxa and columns are samples), and the taxon ID and sample ID are added to the object. This also allows the `import_biom` function from `phyloseq` to work correctly.

```
> biom_data(read_biom("test1.biom"))
       CL3 AQC1cm
549322   0     27

> biom_data(read_biom("test2.biom"))
       AQC1cm
549322     27
522457      0

> import_biom("test1.biom")
phyloseq-class experiment-level object
otu_table()   OTU Table:         [ 1 taxa and 2 samples ]
sample_data() Sample Data:       [ 2 samples by 7 sample variables ]
tax_table()   Taxonomy Table:    [ 1 taxa by 7 taxonomic ranks ]

> import_biom("test2.biom")
phyloseq-class experiment-level object
otu_table()   OTU Table:         [ 2 taxa and 1 samples ]
sample_data() Sample Data:       [ 1 samples by 7 sample variables ]
tax_table()   Taxonomy Table:    [ 2 taxa by 7 taxonomic ranks ]
```